### PR TITLE
Fix proposal for the official image

### DIFF
--- a/OfficialImage/Dockerfile
+++ b/OfficialImage/Dockerfile
@@ -1,22 +1,27 @@
-from node:0.10.39
+FROM node:0.10.39
 
-RUN groupadd -r rocketchat && useradd -r -g rocketchat rocketchat
+MAINTAINER put.your.name@here.com
 
-ENV RC_VERSION v0.4.0
+RUN groupadd -r rocketchat \
+&&  useradd -r -g rocketchat rocketchat
 
 # gpg: key 4FD08014: public key "Rocket.Chat Buildmaster <buildmaster@rocket.chat>" imported
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 0E163286C20D07B9787EBE9FD7F9D0414FD08104 
-RUN curl -fSL "https://rocket.chat/dists/$RC_VERSION/rocket.chat-$RC_VERSION.tgz" -o rocket.chat.tgz \
-    && curl -fSL "https://rocket.chat/dists/$RC_VERSION/rocket.chat-$RC_VERSION.tgz.asc" -o rocket.chat.tgz.asc \
-    && gpg --verify rocket.chat.tgz.asc \
-    && tar zxvf ./rocket.chat.tgz \
-    && rm ./rocket.chat.tgz
 
+ENV RC_VERSION v0.4.0
+
+RUN curl -fSL "https://rocket.chat/dists/$RC_VERSION/rocket.chat-$RC_VERSION.tgz" -o rocket.chat.tgz \
+&&  curl -fSL "https://rocket.chat/dists/$RC_VERSION/rocket.chat-$RC_VERSION.tgz.asc" -o rocket.chat.tgz.asc \
+&&  gpg --verify rocket.chat.tgz.asc \
+&&  tar zxvf ./rocket.chat.tgz \
+&&  rm ./rocket.chat.tgz
 
 WORKDIR /app/bundle/programs/server
 RUN npm i 
 
 WORKDIR /app/bundle
 USER rocketchat
-EXPOSE 80
+ENV PORT=3000
+EXPOSE 3000
 CMD ["node", "main.js"]
+


### PR DESCRIPTION
It is mostly codestyle. (I really like it like this :) )

I moved `gpg` one line upper as it will change less than the `RC_VERSION`.

I added the env var `PORT` if not, meteor was not starting.

I changed the port to 3000 as node will not have the right to start on port 80 from non root.
This part is a bit annoying, as it will not work 'out of the box'.
I tried to find a solution, but there is nothing satisfactory. The best might be to start an nginx in front in the `docker-compose.yml`.
In the mean time on my infrastructure, I just run it as root (like most people do on the Internet apparently).

This is sad.

I also looked at [this](http://stackoverflow.com/a/27805105/1703029) without success :/

I'll ask on StackOverflow, I'll report here if I get responses!

All the best